### PR TITLE
mediaserver: fix compilation of libcameraservice

### DIFF
--- a/media/mediaserver/Android.bp
+++ b/media/mediaserver/Android.bp
@@ -49,7 +49,7 @@ cc_binary {
                 overrides: ["cameraserver"],
                 cflags: ["-DNO_CAMERA_SERVER"],
                 shared_libs: [
-                    "libcameraservice",
+                    "//frameworks/av/services/camera/libcameraservice:libcameraservice",
                     "libgui",
                     "libhidlbase",
                     "libhidltransport",


### PR DESCRIPTION
Fix the following compilation error

error: frameworks/av/media/mediaserver/Android.bp:12:1: "mediaserver" depends on undefined module "libcameraservice"
Module "mediaserver" is defined in namespace "." which can read these 1 namespaces: ["."]
Module "libcameraservice" can be found in these namespaces: ["frameworks/av/services/camera/libcameraservice"]